### PR TITLE
Updating patternfly-next package + components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,9 +60,9 @@
       "dev": true
     },
     "@patternfly/patternfly-next": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly-next/-/patternfly-next-1.0.2.tgz",
-      "integrity": "sha512-YHxBVOIxHuZET9aSNdmZR3R+jAX7PanuuPwi8c79mlbxHypsYJH1xsgy8R17w0ZqyS0uxB8A3FKc/izkJPbqCA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly-next/-/patternfly-next-1.0.3.tgz",
+      "integrity": "sha512-YaHR2B+x3+44AuYFrwRSzRfFM4qfnFwbAk13WLTp5q5jFwRBvVN8Nm/IckmxSGXITB5BVjM1UtpCca11EoLJhA==",
       "dev": true
     },
     "@samverschueren/stream-to-observable": {
@@ -79,264 +79,6 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true
-    },
-    "@types/c3": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/c3/-/c3-0.6.0.tgz",
-      "integrity": "sha512-49E+Oh7KDKd8Dg4WjYh8NvFSZlmPUYuNquJzTvhk+CaBhsN7z+m1U/jmGS4V2QWHxBwj1HT7Hdz2mWbRXEmjQA==",
-      "optional": true,
-      "requires": {
-        "@types/d3": "4.13.0"
-      }
-    },
-    "@types/d3": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-4.13.0.tgz",
-      "integrity": "sha512-L7C+aOIl+z/e7pPBvRXxA9EZ8a5RIZSq4UnTgdjCnypYV3bPI1wpx81snC8pE1zB4SZQC/WK4noZUHzWAABfBA==",
-      "optional": true,
-      "requires": {
-        "@types/d3-array": "1.2.1",
-        "@types/d3-axis": "1.0.10",
-        "@types/d3-brush": "1.0.8",
-        "@types/d3-chord": "1.0.7",
-        "@types/d3-collection": "1.0.7",
-        "@types/d3-color": "1.2.1",
-        "@types/d3-dispatch": "1.0.6",
-        "@types/d3-drag": "1.2.1",
-        "@types/d3-dsv": "0.4.4",
-        "@types/d3-ease": "1.0.7",
-        "@types/d3-force": "1.1.1",
-        "@types/d3-format": "1.3.0",
-        "@types/d3-geo": "1.10.3",
-        "@types/d3-hierarchy": "1.1.2",
-        "@types/d3-interpolate": "1.1.6",
-        "@types/d3-path": "1.0.7",
-        "@types/d3-polygon": "1.0.6",
-        "@types/d3-quadtree": "1.0.5",
-        "@types/d3-queue": "3.0.6",
-        "@types/d3-random": "1.1.1",
-        "@types/d3-request": "1.0.2",
-        "@types/d3-scale": "1.0.13",
-        "@types/d3-selection": "1.3.1",
-        "@types/d3-shape": "1.2.3",
-        "@types/d3-time": "1.0.8",
-        "@types/d3-time-format": "2.1.0",
-        "@types/d3-timer": "1.0.6",
-        "@types/d3-transition": "1.1.1",
-        "@types/d3-voronoi": "1.1.7",
-        "@types/d3-zoom": "1.7.1"
-      }
-    },
-    "@types/d3-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.1.tgz",
-      "integrity": "sha512-YBaAfimGdWE4nDuoGVKsH89/dkz2hWZ0i8qC+xxqmqi+XJ/aXiRF0jPtzXmN7VdkpVjy1xuDmM5/m1FNuB6VWA==",
-      "optional": true
-    },
-    "@types/d3-axis": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.10.tgz",
-      "integrity": "sha512-5YF0wfdQMPKw01VAAupLIlg/T4pn5M3/vL9u0KZjiemnVnnKBEWE24na4X1iW+TfZiYJ8j+BgK2KFYnAAT54Ug==",
-      "optional": true,
-      "requires": {
-        "@types/d3-selection": "1.3.1"
-      }
-    },
-    "@types/d3-brush": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.0.8.tgz",
-      "integrity": "sha512-9Thv09jvolu9T1BE3fHmIeYSgbwSpdxtF6/A5HZEDjSTfgtA0mtaXRk5AiWOo0KjuLsI+/7ggD3ZGN5Ye8KXPQ==",
-      "optional": true,
-      "requires": {
-        "@types/d3-selection": "1.3.1"
-      }
-    },
-    "@types/d3-chord": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.7.tgz",
-      "integrity": "sha512-WbCN7SxhZMpQQw46oSjAovAmvl3IdjhLuQ4r7AXCzNKyxtXXBWuihSPZ4bVwFQF3+S2z37i9d4hfUBatcSJpog==",
-      "optional": true
-    },
-    "@types/d3-collection": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-collection/-/d3-collection-1.0.7.tgz",
-      "integrity": "sha512-vR3BT0GwHc5y93Jv6bxn3zoxP/vGu+GdXu/r1ApjbP9dLk9I2g6NiV7iP/QMQSuFZd0It0n/qWrfXHxCWwHIkg==",
-      "optional": true
-    },
-    "@types/d3-color": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.2.1.tgz",
-      "integrity": "sha512-xwb1tqvYNWllbHuhMFhiXk63Imf+QNq/dJdmbXmr2wQVnwGenCuj3/0IWJ9hdIFQIqzvhT7T37cvx93jtAsDbQ=="
-    },
-    "@types/d3-dispatch": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
-      "integrity": "sha512-xyWJQMr832vqhu6fD/YqX+MSFBWnkxasNhcStvlhqygXxj0cKqPft0wuGoH5TIq5ADXgP83qeNVa4R7bEYN3uA==",
-      "optional": true
-    },
-    "@types/d3-drag": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.1.tgz",
-      "integrity": "sha512-J9liJ4NNeV0oN40MzPiqwWjqNi3YHCRtHNfNMZ1d3uL9yh1+vDuo346LBEr8yyBm30WHvrHssAkExVZrGCswtA==",
-      "optional": true,
-      "requires": {
-        "@types/d3-selection": "1.3.1"
-      }
-    },
-    "@types/d3-dsv": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-0.4.4.tgz",
-      "integrity": "sha512-p+JzCAWJSDdr0XNaQ6jpG14w7n8C4Iq9T1dPJaWS/qTaG7uqUNgDF0d2MyLpQ6xslkOUxNXDp4k0grfi4VlCdQ=="
-    },
-    "@types/d3-ease": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.7.tgz",
-      "integrity": "sha1-k6MBhovp4VBh89RDQ7GrP4rLbwk=",
-      "optional": true
-    },
-    "@types/d3-force": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.1.1.tgz",
-      "integrity": "sha512-ePkELuaFWY4yOuf+Bvx5Xd+ihFiYG4bdnW0BlvigovIm8Sob2t76e9RGO6lybQbv6AlW9Icn9HuZ9fmdzEoJyg==",
-      "optional": true
-    },
-    "@types/d3-format": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.3.0.tgz",
-      "integrity": "sha512-ZiY4j3iJvAdOwzwW24WjlZbUNvqOsnPAMfPBmdXqxj3uKJbrzBlRrdGl5uC89pZpFs9Dc92E81KcwG2uEgkIZA==",
-      "optional": true
-    },
-    "@types/d3-geo": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.10.3.tgz",
-      "integrity": "sha512-hfdaxM2L0wA9mDZrrSf2o+DyhEpnJYCiAN+lHFtpfZOVCQrYBA5g33sGRpUbAvjSMyO5jkHbftMWPEhuCMChSg==",
-      "optional": true,
-      "requires": {
-        "@types/geojson": "7946.0.3"
-      }
-    },
-    "@types/d3-hierarchy": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.2.tgz",
-      "integrity": "sha512-L+Ht4doqlCIH8jYN2AC1mYIOj13OxlRhdWNWXv2pc3o5A9i3YmQ0kz6A7w8c+Ujylfusi/FO+zVlVnQoOHc2Qw==",
-      "optional": true
-    },
-    "@types/d3-interpolate": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
-      "integrity": "sha1-ZAQbFcnAMsNI2hsiuqvFn6TRYTY=",
-      "requires": {
-        "@types/d3-color": "1.2.1"
-      }
-    },
-    "@types/d3-path": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.7.tgz",
-      "integrity": "sha512-U8dFRG+8WhkLJr2sxZ9Cw/5WeRgBnNqMxGdA1+Z0+ZG6tK0s75OQ4OXnxeyfKuh6E4wQPY8OAKr1+iNDx01BEQ=="
-    },
-    "@types/d3-polygon": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.6.tgz",
-      "integrity": "sha512-E6Kyodn9JThgLq20nxSbEce9ow5/ePgm9PX2EO6W1INIL4DayM7cFaiG10DStuamjYAd0X4rntW2q+GRjiIktw==",
-      "optional": true
-    },
-    "@types/d3-quadtree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.5.tgz",
-      "integrity": "sha1-HOHmWerkUw3wyxJ/KX8XQaNnqC4=",
-      "optional": true
-    },
-    "@types/d3-queue": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-queue/-/d3-queue-3.0.6.tgz",
-      "integrity": "sha512-CGGs7QeUs4F9YoD7KM0l4jwQ3wj2UqVLIweRk/OxF5n3ujnSJoT/wzIl2TCR0TiY88LEAnBfW+LhEJm9famk6A==",
-      "optional": true
-    },
-    "@types/d3-random": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.1.tgz",
-      "integrity": "sha512-jUPeBq1XKK9/5XasTvy5QAUwFeMsjma2yt/nP02yC2Tijovx7i/W5776U/HZugxc5SSmtpx4Z3g9KFVon0QrjQ==",
-      "optional": true
-    },
-    "@types/d3-request": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-request/-/d3-request-1.0.2.tgz",
-      "integrity": "sha1-2524FU9HgWWEcGxub3Ar5m8i9L4=",
-      "optional": true,
-      "requires": {
-        "@types/d3-dsv": "0.4.4"
-      }
-    },
-    "@types/d3-scale": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-1.0.13.tgz",
-      "integrity": "sha512-VkytFyGGRVNBn/CBfvstjta9elXALBAgg9yTqHHAglOTTR8EhPDQYBnMwE2kOYxu32kBXzUNXKdFCA9YejKjnw==",
-      "optional": true,
-      "requires": {
-        "@types/d3-time": "1.0.8"
-      }
-    },
-    "@types/d3-selection": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.3.1.tgz",
-      "integrity": "sha512-G+eO+2G1iW3GNrROxhoU+ar+bIJbQq1QkxcfhwjQ19xA20n3T31j5pSJqAOWvPSoFTz4Ets/DQgYhmgT4jepDg=="
-    },
-    "@types/d3-shape": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.2.3.tgz",
-      "integrity": "sha512-iP9TcX0EVi+LlX+jK9ceS+yhEz5abTitF+JaO2ugpRE/J+bccaYLe/0/3LETMmdaEkYarIyboZW8OF67Mpnj1w==",
-      "optional": true,
-      "requires": {
-        "@types/d3-path": "1.0.7"
-      }
-    },
-    "@types/d3-time": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.0.8.tgz",
-      "integrity": "sha512-/UCphyyw97YAq4zKsuXH33R3UNB4jDSza0fLvMubWr/ONh9IePi1NbgFP222blhiCe724ebJs8U87+aDuAq/jA=="
-    },
-    "@types/d3-time-format": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
-      "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==",
-      "optional": true
-    },
-    "@types/d3-timer": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.6.tgz",
-      "integrity": "sha1-eG1OIHMa3wOvLF32yG/ilmf+Qps=",
-      "optional": true
-    },
-    "@types/d3-transition": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.1.1.tgz",
-      "integrity": "sha512-GHTghl0YYB8gGgbyKxVLHyAp9Na0HqsX2U7M0u0lGw4IdfEaslooykweZ8fDHW13T+KZeZAuzhbmqBZVFO+6kg==",
-      "optional": true,
-      "requires": {
-        "@types/d3-selection": "1.3.1"
-      }
-    },
-    "@types/d3-voronoi": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.7.tgz",
-      "integrity": "sha512-/dHFLK5jhXTb/W4XEQcFydVk8qlIAo85G3r7+N2fkBFw190l0R1GQ8C1VPeXBb2GfSU5GbT2hjlnE7i7UY5Gvg==",
-      "optional": true
-    },
-    "@types/d3-zoom": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.7.1.tgz",
-      "integrity": "sha512-Ofjwz6Pt53tRef9TAwwayN+JThNVYC/vFOepa/H4KtwjhsqkmEseHvc2jpJM7vye5PQ5XHtTSOpdY4Y/6xZWEg==",
-      "optional": true,
-      "requires": {
-        "@types/d3-interpolate": "1.1.6",
-        "@types/d3-selection": "1.3.1"
-      }
-    },
-    "@types/geojson": {
-      "version": "7946.0.3",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.3.tgz",
-      "integrity": "sha512-BYHiG1vQJ7T93uswzuXZ0OBPWqj5tsAPtaMDQADV8sn2InllXarwg9llr6uaW22q1QCwBZ81gVajOpYWzjesug==",
-      "optional": true
     },
     "@webassemblyjs/ast": {
       "version": "1.4.3",
@@ -9280,6 +9022,264 @@
         "patternfly-bootstrap-treeview": "2.1.5"
       },
       "dependencies": {
+        "@types/c3": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@types/c3/-/c3-0.6.0.tgz",
+          "integrity": "sha512-49E+Oh7KDKd8Dg4WjYh8NvFSZlmPUYuNquJzTvhk+CaBhsN7z+m1U/jmGS4V2QWHxBwj1HT7Hdz2mWbRXEmjQA==",
+          "optional": true,
+          "requires": {
+            "@types/d3": "4.13.0"
+          }
+        },
+        "@types/d3": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@types/d3/-/d3-4.13.0.tgz",
+          "integrity": "sha512-L7C+aOIl+z/e7pPBvRXxA9EZ8a5RIZSq4UnTgdjCnypYV3bPI1wpx81snC8pE1zB4SZQC/WK4noZUHzWAABfBA==",
+          "optional": true,
+          "requires": {
+            "@types/d3-array": "1.2.1",
+            "@types/d3-axis": "1.0.10",
+            "@types/d3-brush": "1.0.7",
+            "@types/d3-chord": "1.0.6",
+            "@types/d3-collection": "1.0.6",
+            "@types/d3-color": "1.2.1",
+            "@types/d3-dispatch": "1.0.6",
+            "@types/d3-drag": "1.2.0",
+            "@types/d3-dsv": "1.0.31",
+            "@types/d3-ease": "1.0.7",
+            "@types/d3-force": "1.1.0",
+            "@types/d3-format": "1.3.0",
+            "@types/d3-geo": "1.10.2",
+            "@types/d3-hierarchy": "1.1.1",
+            "@types/d3-interpolate": "1.1.6",
+            "@types/d3-path": "1.0.6",
+            "@types/d3-polygon": "1.0.6",
+            "@types/d3-quadtree": "1.0.5",
+            "@types/d3-queue": "3.0.5",
+            "@types/d3-random": "1.1.0",
+            "@types/d3-request": "1.0.2",
+            "@types/d3-scale": "1.0.12",
+            "@types/d3-selection": "1.3.0",
+            "@types/d3-shape": "1.2.2",
+            "@types/d3-time": "1.0.7",
+            "@types/d3-time-format": "2.1.0",
+            "@types/d3-timer": "1.0.6",
+            "@types/d3-transition": "1.1.1",
+            "@types/d3-voronoi": "1.1.7",
+            "@types/d3-zoom": "1.7.0"
+          }
+        },
+        "@types/d3-array": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-1.2.1.tgz",
+          "integrity": "sha512-YBaAfimGdWE4nDuoGVKsH89/dkz2hWZ0i8qC+xxqmqi+XJ/aXiRF0jPtzXmN7VdkpVjy1xuDmM5/m1FNuB6VWA==",
+          "optional": true
+        },
+        "@types/d3-axis": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-1.0.10.tgz",
+          "integrity": "sha512-5YF0wfdQMPKw01VAAupLIlg/T4pn5M3/vL9u0KZjiemnVnnKBEWE24na4X1iW+TfZiYJ8j+BgK2KFYnAAT54Ug==",
+          "optional": true,
+          "requires": {
+            "@types/d3-selection": "1.3.0"
+          }
+        },
+        "@types/d3-brush": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-1.0.7.tgz",
+          "integrity": "sha1-BcMEQPTVN/0j+Xaw5sS6IjAB70U=",
+          "optional": true,
+          "requires": {
+            "@types/d3-selection": "1.3.0"
+          }
+        },
+        "@types/d3-chord": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-1.0.6.tgz",
+          "integrity": "sha1-BYnrl6MZH07a8Xt73kmEYokM4ew=",
+          "optional": true
+        },
+        "@types/d3-collection": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@types/d3-collection/-/d3-collection-1.0.6.tgz",
+          "integrity": "sha512-UHBvaU2wT5GlJN6rRVQm42211uAyZtp7m0jpQFuMuX7hTuivc0tcF0cjx5Ny5eQkhIolEyKwWgvJexw4e8g4+A==",
+          "optional": true
+        },
+        "@types/d3-color": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.2.1.tgz",
+          "integrity": "sha512-xwb1tqvYNWllbHuhMFhiXk63Imf+QNq/dJdmbXmr2wQVnwGenCuj3/0IWJ9hdIFQIqzvhT7T37cvx93jtAsDbQ=="
+        },
+        "@types/d3-dispatch": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+          "integrity": "sha512-xyWJQMr832vqhu6fD/YqX+MSFBWnkxasNhcStvlhqygXxj0cKqPft0wuGoH5TIq5ADXgP83qeNVa4R7bEYN3uA==",
+          "optional": true
+        },
+        "@types/d3-drag": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-1.2.0.tgz",
+          "integrity": "sha512-AePmm0sXj0Tpl0uQWvwmbAf1QR3yCy9aRhjJ9mRDDSZlHBdY0SCpUtdZC9uG9Q+pyHT/dEt1R2FT/sj+5k/bVA==",
+          "optional": true,
+          "requires": {
+            "@types/d3-selection": "1.3.0"
+          }
+        },
+        "@types/d3-dsv": {
+          "version": "1.0.31",
+          "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.0.31.tgz",
+          "integrity": "sha512-UCAVZdwd2NkrbkF1lZu9vzTlmUENRRrPCubyhDPlG8Ye1B8Xr2PNvk/Tp8tMm6sPoWZWagri6/P9H+t7WqkGDg=="
+        },
+        "@types/d3-ease": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-1.0.7.tgz",
+          "integrity": "sha1-k6MBhovp4VBh89RDQ7GrP4rLbwk=",
+          "optional": true
+        },
+        "@types/d3-force": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-1.1.0.tgz",
+          "integrity": "sha512-a39Uu/ltLaMpj6K0elEB1oAqhx9rlTB5X/O75uTUqyTW2CfjhPXg6hFsX1lF8oeMc29kqGJZ4g9Pf6mET25bVw==",
+          "optional": true
+        },
+        "@types/d3-format": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.3.0.tgz",
+          "integrity": "sha512-ZiY4j3iJvAdOwzwW24WjlZbUNvqOsnPAMfPBmdXqxj3uKJbrzBlRrdGl5uC89pZpFs9Dc92E81KcwG2uEgkIZA==",
+          "optional": true
+        },
+        "@types/d3-geo": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-1.10.2.tgz",
+          "integrity": "sha512-3VvrHG5e9PNWyusAsqHtHWzAYHcOxOrpacA/p527KUpSZKJybKeF9wqSyQgIeV0qZuh/FYMv4vlwQzeXgPQYlg==",
+          "optional": true,
+          "requires": {
+            "@types/geojson": "7946.0.3"
+          }
+        },
+        "@types/d3-hierarchy": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-1.1.1.tgz",
+          "integrity": "sha512-2JYl75eoSdtqfmwIqf9TN7kWmT+/PBfz7Qejdn77gAu/k5HSqBINYVnciLRcjWzKq+lAujGypFuAAQ4zaGKxxg==",
+          "optional": true
+        },
+        "@types/d3-interpolate": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
+          "integrity": "sha1-ZAQbFcnAMsNI2hsiuqvFn6TRYTY=",
+          "requires": {
+            "@types/d3-color": "1.2.1"
+          }
+        },
+        "@types/d3-path": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.6.tgz",
+          "integrity": "sha512-YHW4cs+wOU9gFUzudjJs9TkrB/8GOgKhq32ZyNaZ2rzZjOhkqG486sGr9XSh4C91CcgIg1FRGoDaN29Ropx9nw=="
+        },
+        "@types/d3-polygon": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-1.0.6.tgz",
+          "integrity": "sha512-E6Kyodn9JThgLq20nxSbEce9ow5/ePgm9PX2EO6W1INIL4DayM7cFaiG10DStuamjYAd0X4rntW2q+GRjiIktw==",
+          "optional": true
+        },
+        "@types/d3-quadtree": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-1.0.5.tgz",
+          "integrity": "sha1-HOHmWerkUw3wyxJ/KX8XQaNnqC4=",
+          "optional": true
+        },
+        "@types/d3-queue": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@types/d3-queue/-/d3-queue-3.0.5.tgz",
+          "integrity": "sha1-Pky+Kv9h22oLK4xIACmeTsasyFA=",
+          "optional": true
+        },
+        "@types/d3-random": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-1.1.0.tgz",
+          "integrity": "sha1-LdCPEVnHBxknDkp8g0r4XIuI0sM=",
+          "optional": true
+        },
+        "@types/d3-request": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@types/d3-request/-/d3-request-1.0.2.tgz",
+          "integrity": "sha1-2524FU9HgWWEcGxub3Ar5m8i9L4=",
+          "optional": true,
+          "requires": {
+            "@types/d3-dsv": "1.0.31"
+          }
+        },
+        "@types/d3-scale": {
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-1.0.12.tgz",
+          "integrity": "sha512-2Z3YsHdWRBuUiqKHcnWVF1ffuALFn+k74QEECUCpzabD/5Olxvs/aJM4eG3QTe5n9yiWK432kOEpinGvO1wDfA==",
+          "optional": true,
+          "requires": {
+            "@types/d3-time": "1.0.7"
+          }
+        },
+        "@types/d3-selection": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.3.0.tgz",
+          "integrity": "sha512-1SJhi3kTk/SHHIE6XkHuHU2REYkbSOjkQuo3HT71FOTs8/tjeGcvtXMsX4N3kU1UE1nVG+A5pg7TSjuJ4zUN3A=="
+        },
+        "@types/d3-shape": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.2.2.tgz",
+          "integrity": "sha512-Ydksrces8J5WP/NXhZ/CcDx/XZZ8b7MDX+u6WGQXwEWfmimJn9eYHiD7QR4BLe3zBiAOQmmiGAwRBKUDp5zb1g==",
+          "optional": true,
+          "requires": {
+            "@types/d3-path": "1.0.6"
+          }
+        },
+        "@types/d3-time": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.0.7.tgz",
+          "integrity": "sha512-X5ZQYiJIM38XygNwld4gZ++Vtw2ftgo3KOfZOY4n/sCudUxclxf/3THBvuG8UqSV+EQ0ezYjT5eyvcrrmixOWA=="
+        },
+        "@types/d3-time-format": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
+          "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==",
+          "optional": true
+        },
+        "@types/d3-timer": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.6.tgz",
+          "integrity": "sha1-eG1OIHMa3wOvLF32yG/ilmf+Qps=",
+          "optional": true
+        },
+        "@types/d3-transition": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.1.1.tgz",
+          "integrity": "sha512-GHTghl0YYB8gGgbyKxVLHyAp9Na0HqsX2U7M0u0lGw4IdfEaslooykweZ8fDHW13T+KZeZAuzhbmqBZVFO+6kg==",
+          "optional": true,
+          "requires": {
+            "@types/d3-selection": "1.3.0"
+          }
+        },
+        "@types/d3-voronoi": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.7.tgz",
+          "integrity": "sha512-/dHFLK5jhXTb/W4XEQcFydVk8qlIAo85G3r7+N2fkBFw190l0R1GQ8C1VPeXBb2GfSU5GbT2hjlnE7i7UY5Gvg==",
+          "optional": true
+        },
+        "@types/d3-zoom": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.7.0.tgz",
+          "integrity": "sha512-eIivt2ehMUXqS0guuVzRSMr5RGhO958g9EKxIJv3Z23suPnX4VQI9k1TC/bLuwKq0IWp9a1bEEcIy+PNJv9BtA==",
+          "optional": true,
+          "requires": {
+            "@types/d3-interpolate": "1.1.6",
+            "@types/d3-selection": "1.3.0"
+          }
+        },
+        "@types/geojson": {
+          "version": "7946.0.3",
+          "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.3.tgz",
+          "integrity": "sha512-BYHiG1vQJ7T93uswzuXZ0OBPWqj5tsAPtaMDQADV8sn2InllXarwg9llr6uaW22q1QCwBZ81gVajOpYWzjesug==",
+          "optional": true
+        },
         "bootstrap": {
           "version": "3.3.7",
           "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10490,14 +10490,6 @@
         }
       }
     },
-    "react-patternfly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/react-patternfly/-/react-patternfly-1.0.0.tgz",
-      "integrity": "sha1-YJNR8HIu6rJ2q5p4ZBz0rAXPuTI=",
-      "requires": {
-        "classnames": "2.2.5"
-      }
-    },
     "react-prop-types": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fontAwesome": "node_modules/patternfly/node_modules/font-awesome-sass/assets/stylesheets"
   },
   "devDependencies": {
-    "@patternfly/patternfly-next": "^1.0.2",
+    "@patternfly/patternfly-next": "^1.0.3",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
     "babel-plugin-dual-import": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "create-react-class": "^15.6.3",
-    "patternfly-react": "^2.3.4",
-    "react-patternfly": "^1.0.0"
+    "patternfly-react": "^2.3.4"
   },
   "sassIncludes": {
     "patternfly": "node_modules/patternfly/dist/sass",

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,6 +1,6 @@
 $pf-global--enable-font-overpass-cdn: true;
 @import 'patternfly_specific';
-@import '~@patternfly/patternfly-next/patternfly';
+@import '~@patternfly/patternfly-next/patternfly.css';
 @import './src/Utilities.scss';
 
 html, body {

--- a/src/PresentationalComponents/Button/button.js
+++ b/src/PresentationalComponents/Button/button.js
@@ -18,12 +18,12 @@ export default props => {
 
     let btnClasses = classNames(
       'pf-c-button',
-      { [`pf-is-${props.type}`]: props.type !== undefined },
+      { 
+        [`pf-is-${props.type}`]: props.type !== undefined && props.type !== 'alternate',
+        [`pf-is-secondary-alt`]: props.type !== undefined && props.type === 'alternate' 
+      },
       { [`pf-is-${props.size}`]: props.size !== undefined },
-      {
-        'pf-has-focus': props.state === 'focused',
-        [`pf-is-${props.state}`]: props.state === 'active' || props.state === 'disabled'
-      }
+      { [`pf-is-${props.state}`]: props.state !== undefined }
     );
 
      return (

--- a/src/PresentationalComponents/Section/section.js
+++ b/src/PresentationalComponents/Section/section.js
@@ -15,7 +15,8 @@ import './section.scss';
 export default props => {
 
     let sectionClasses = classNames(
-      { [`ins-l-${props.type}`]: props.type !== undefined }
+      { [`ins-l-${props.type}`]: props.type !== undefined },
+      { [`ins-l-is-dark`]: props.dark }
     );
 
      return (

--- a/src/PresentationalComponents/Section/section.scss
+++ b/src/PresentationalComponents/Section/section.scss
@@ -9,3 +9,7 @@ section.ins-l-button-group {
   * + * { @include rem('margin-left', 5px); }
   @include rem('margin', $global-margin 0);
 }
+
+section.ins-l-is-dark {
+  background: black;
+}

--- a/src/SmartComponents/SamplePage/SamplePage.js
+++ b/src/SmartComponents/SamplePage/SamplePage.js
@@ -53,11 +53,13 @@ class SamplePage extends Component<RouteProps<any> & Props, State> {
                     </Card>
                     <h1> Buttons </h1>
                     <Section type='button-group'>
-                        <Button> PF-Next Primary Button </Button>
                         <Button type='primary'> PF-Next Primary Button </Button>
                         <Button type='secondary'> PF-Next Secondary Button </Button>
                         <Button type='tertiary'> PF-Next Tertiary Button </Button>
                         <Button type='danger'> PF-Next Danger Button </Button>
+                    </Section>
+                    <Section type='button-group' dark='true'>
+                        <Button type='alternate'> PF-Next Primary Button </Button>
                     </Section>
                     <Section type='button-group'>
                         <PF3Button> PF-3 Default </PF3Button>

--- a/src/Utilities/_colors.scss
+++ b/src/Utilities/_colors.scss
@@ -1,4 +1,6 @@
-@import 'node_modules/@patternfly/patternfly-next/utilities/colors.scss';
+:root {
+    @import 'node_modules/@patternfly/patternfly-next/utilities/colors.scss';
+}
 
 // Sample Colors
 $light: #e9e9e9;


### PR DESCRIPTION
We updated to PF-Next 1.0.3 which changes file structure, adds CSS variables, and updated components. This should fix all the rendering issues with that.

Removing react-patternfly (last updated in 2016), but keeping patternfly-react 