### PR TITLE
Killing bundle analyzer

### DIFF
--- a/config/dev.webpack.plugins.js
+++ b/config/dev.webpack.plugins.js
@@ -3,13 +3,4 @@
 
 const { plugins } = require('./base.webpack.plugins');
 
-/**
- * Generates html that shows an analysis of code bundles.
- *
- * @type {var}
- */
-plugins.push(new (require('webpack-bundle-analyzer').BundleAnalyzerPlugin)({
-    openAnalyzer: false
-}));
-
 module.exports = { plugins };


### PR DESCRIPTION
Do we really need a bundle analyzer? I think it should be optional for teams to look at if they want, but not to bloat anything else.

Plus, I was getting weird errors running the analyzer