### PR TITLE
Change config for lodash-webpack to correctly use some functions

### DIFF
--- a/config/base.webpack.plugins.js
+++ b/config/base.webpack.plugins.js
@@ -51,7 +51,7 @@ plugins.push(CleanWebpackPlugin);
  *
  * @type {var}
  */
-const LodashWebpackPlugin = new (require('lodash-webpack-plugin'))();
+const LodashWebpackPlugin = new (require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true });
 plugins.push(LodashWebpackPlugin);
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insights-frontend-starter-app",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": false,
   "dependencies": {
     "@patternfly/react-core": "1.0.0",


### PR DESCRIPTION
When using lodash functions there are some problems with missing `currying`, `flattening` or `placeholders`. This happens for instance when trying to use PF3 components (since many of them are using lodash under the hood). This config change will fix such issues.