### PR TITLE
updating lint for jsx

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,7 +21,10 @@ globals:
   shallow: true
   React: true
 rules:
-  array-bracket-spacing: 2
+  array-bracket-spacing:
+    - error
+    - always
+    - objectsInArrays: false
   comma-dangle: 2
   comma-spacing:
     - 2
@@ -44,6 +47,14 @@ rules:
       MemberExpression: 0
       ImportDeclaration: 1
       ObjectExpression: 1
+  react/jsx-curly-spacing:
+    - error
+    - always
+    - children: true
+    - allowMultiline: false
+    - spacing:
+      - objectLiterals:
+        - never
   key-spacing: 2
   keyword-spacing: 2
   linebreak-style:
@@ -51,7 +62,7 @@ rules:
     - unix
   max-len:
     - 2
-    - 130
+    - 150
   new-cap: 2
   no-bitwise: 2
   no-caller: 2
@@ -71,6 +82,8 @@ rules:
   object-curly-spacing:
     - error
     - always
+    - objectsInObjects: false
+      arraysInObjects: false
   one-var:
     - error
     - never

--- a/config/base.webpack.plugins.js
+++ b/config/base.webpack.plugins.js
@@ -43,7 +43,7 @@ plugins.push(SourceMapsPlugin);
  * Cleans distribution folder.
  * @type {[type]}
  */
-const CleanWebpackPlugin = new (require('clean-webpack-plugin'))(['dist']);
+const CleanWebpackPlugin = new (require('clean-webpack-plugin'))([ 'dist' ]);
 plugins.push(CleanWebpackPlugin);
 
 /**

--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,7 @@ class App extends Component {
 
     render () {
         return (
-            <Routes childProps={this.props} />
+            <Routes childProps={ this.props } />
         );
     }
 }

--- a/src/PresentationalComponents/Rules/Rules.js
+++ b/src/PresentationalComponents/Rules/Rules.js
@@ -10,8 +10,8 @@ const Rules = () => {
         <React.Fragment>
             <h1>Rules</h1>
             <Switch>
-                <Route exact path='/advisor/rules' component={ListRules} />
-                <Route path='/advisor/rules/:id' component={ViewRule} />
+                <Route exact path='/advisor/rules' component={ ListRules } />
+                <Route path='/advisor/rules/:id' component={ ViewRule } />
             </Switch>
         </React.Fragment>
     );

--- a/src/PresentationalComponents/Rules/ViewRule.js
+++ b/src/PresentationalComponents/Rules/ViewRule.js
@@ -7,7 +7,7 @@ const ViewRule = (props) => {
         <React.Fragment>
             <PageHeader>
                 <PageHeaderTitle title='Rules Page'/>
-                <p> {props.match.params.id} </p>
+                <p> { props.match.params.id } </p>
             </PageHeader>
             <Main>
                 <p> content </p>

--- a/src/PresentationalComponents/SampleComponent/sample-component.js
+++ b/src/PresentationalComponents/SampleComponent/sample-component.js
@@ -10,7 +10,7 @@ import React from 'react';
  */
 const SampleComponent = (props) => {
     return (
-        <span className='sample-component'> {props.children} </span>
+        <span className='sample-component'> { props.children } </span>
     );
 };
 

--- a/src/PresentationalComponents/SampleComponent/sample-component.test.js
+++ b/src/PresentationalComponents/SampleComponent/sample-component.test.js
@@ -6,7 +6,7 @@ describe('sample-component', () => {
 
         const wrapper = shallow(
             <SampleComponent>
-                {children}
+                { children }
             </SampleComponent>
         );
         expect(wrapper.prop('children')).toContain(children);

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -35,7 +35,7 @@ const InsightsRoute = ({ component: Component, rootClass, ...rest }) => {
     root.classList.add(`page__${rootClass}`, 'pf-l-page__main');
     root.setAttribute('role', 'main');
 
-    return (<Component {...rest} />);
+    return (<Component { ...rest } />);
 };
 
 InsightsRoute.propTypes = {
@@ -56,11 +56,11 @@ export const Routes = (props: Props) => {
 
     return (
         <Switch>
-            <InsightsRoute path={paths.samplepage} component={SamplePage} rootClass='samplepage' />
-            <InsightsRoute path={paths.rules} component={Rules} rootClass='rules' />
+            <InsightsRoute path={ paths.samplepage } component={ SamplePage } rootClass='samplepage'/>
+            <InsightsRoute path={ paths.rules } component={ Rules } rootClass='rules'/>
 
-            {/* Finally, catch all unmatched routes */}
-            <Route render={() => some(paths, p => p === path) ? null : (<Redirect to={paths.samplepage} />)} />
+            { /* Finally, catch all unmatched routes */ }
+            <Route render={ () => some(paths, p => p === path) ? null : (<Redirect to={ paths.samplepage }/>) }/>
         </Switch>
     );
 };

--- a/src/Utilities/asyncComponent.js
+++ b/src/Utilities/asyncComponent.js
@@ -39,7 +39,7 @@ export default function asyncComponent(importComponent) {
         render() {
             const C = this.state.component;
 
-            return C ? <C {...this.props} /> : <div>Loading...</div>;
+            return C ? <C { ...this.props } /> : <div>Loading...</div>;
         }
     }
 

--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -11,7 +11,7 @@ import logger from 'redux-logger';
  *  https://redux.js.org/advanced/usage-with-react-router
  */
 ReactDOM.render(
-    <Provider store={init(logger).getStore()}>
+    <Provider store={ init(logger).getStore() }>
         <Router basename='/insights/platform/advisor'>
             <App/>
         </Router>

--- a/src/entry.js
+++ b/src/entry.js
@@ -10,7 +10,7 @@ import App from './App';
  *  https://redux.js.org/advanced/usage-with-react-router
  */
 ReactDOM.render(
-    <Provider store={init().getStore()}>
+    <Provider store={ init().getStore() }>
         <Router basename='/insights/platform/advisor'>
             <App />
         </Router>


### PR DESCRIPTION
This changes markup, but is non breaking

### Issue: #34 

## Curly Braces
Applies to:
objects in arrays
objects in objects
return statements

Before, these only worked outside of `return` statements and also wouldn't check if the curly braces were inside another array or inside of an object.

## Brackets
Brackets now follow similar rules to curly braces where they require a space inside.
Formerly: `[foo, bar]`
Proposed: `[ foo, bar ]`