### PR TITLE
Remove dist before a build

### DIFF
--- a/config/base.webpack.plugins.js
+++ b/config/base.webpack.plugins.js
@@ -44,7 +44,12 @@ plugins.push(SourceMapsPlugin);
  * Cleans distribution folder.
  * @type {[type]}
  */
-const CleanWebpackPlugin = new (require('clean-webpack-plugin'))([ 'dist' ]);
+const CleanWebpackPlugin = new (require('clean-webpack-plugin'))(
+    [ 'dist' ],
+    {
+        root: path.resolve(__dirname, '../')
+    }
+);
 plugins.push(CleanWebpackPlugin);
 
 /**


### PR DESCRIPTION
Prior to this change, this attempted to clean up config/dist which
does not exist leaving the existing dist intact.