### PR TITLE
Update index.html to use / before @@env

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta charset="UTF-8">
         <title>Starter App</title>
-        <esi:include src="@@env/chrome/snippets/head.html"/>
+        <esi:include src="/@@env/chrome/snippets/head.html"/>
     </head>
     <body>
-        <esi:include src="@@env/chrome/snippets/body.html"/>
+        <esi:include src="/@@env/chrome/snippets/body.html"/>
     </body>
 </html>


### PR DESCRIPTION
cc: @AllenBW 

There is a problem with the [common webpack config](https://github.com/RedHatInsights/frontend-components/blob/9d3e62a96b79272acccb3b32f1f9f26ea45fa600/packages/config/index.js#L12).

There is no preceding `/` before `beta` or `apps`, so chrome isn't serving from the right place.

This adds the `/` to the `@@env` so that everything works correctly.