### PR TITLE
Fix basename for apps that exist both at top-level and below

### DIFF
--- a/src/Utilities/getBaseName.js
+++ b/src/Utilities/getBaseName.js
@@ -9,8 +9,7 @@ function getBaseName(pathname) {
         release = `/beta/`;
     }
 
-    return `${release}${pathName[0]}/${pathName[1]}`;
+    return `${release}${pathName[0]}/${pathName[1] || ''}`;
 }
 
 export default getBaseName;
-


### PR DESCRIPTION
This is so we don't have things like `/ansible/undefined/dashboard`, etc.
My only worry is if we have any bundle-level apps in the future that accept path parameters... like `/ansible/testID40913foo`, or something. Nobody does that yet, but we may have to prepare for that in the future.