### PR TITLE
Remove old (and now unused) `buildNavigation`

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,15 +12,12 @@ class App extends Component {
         // TODO change this to your appname
         // TODO should the sample app webpack just rewrite this automatically?
         insights.chrome.identifyApp('insights');
-        insights.chrome.navigation(buildNavigation());
 
         this.appNav = insights.chrome.on('APP_NAVIGATION', event => this.props.history.push(`/${event.navId}`));
-        this.buildNav = this.props.history.listen(() => insights.chrome.navigation(buildNavigation()));
     }
 
     componentWillUnmount () {
         this.appNav();
-        this.buildNav();
     }
 
     render () {
@@ -40,17 +37,3 @@ App.propTypes = {
  *          https://reactjs.org/docs/higher-order-components.html
  */
 export default withRouter (connect()(App));
-
-function buildNavigation () {
-    const currentPath = window.location.pathname.split('/').slice(-1)[0];
-    return [{
-        title: 'Actions',
-        id: 'actions'
-    }, {
-        title: 'Rules',
-        id: 'rules'
-    }].map(item => ({
-        ...item,
-        active: item.id === currentPath
-    }));
-}


### PR DESCRIPTION

> That's an old thing, left behind. You can remove this, it doesn't do anything. We might want to remove that from starter app as well.

//cc: @karelhala 