### PR TITLE
add spandx config for starter app

### DIFF
--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,5 +1,3 @@
-/*global module, process*/
-
 // Hack so that Mac OSX docker can sub in host.docker.internal instead of localhost
 // see https://docs.docker.com/docker-for-mac/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
 const localhost = (process.env.PLATFORM === 'linux') ? 'localhost' : 'host.docker.internal';
@@ -7,6 +5,6 @@ const localhost = (process.env.PLATFORM === 'linux') ? 'localhost' : 'host.docke
 module.exports = {
     routes: {
         '/apps/starter': { host: `https://${localhost}:8002` },
-        '/insights/starter': { host: `https://${localhost}:8002` },
+        '/insights/starter': { host: `https://${localhost}:8002` }
     }
 };

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,0 +1,12 @@
+/*global module, process*/
+
+// Hack so that Mac OSX docker can sub in host.docker.internal instead of localhost
+// see https://docs.docker.com/docker-for-mac/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
+const localhost = (process.env.PLATFORM === 'linux') ? 'localhost' : 'host.docker.internal';
+
+module.exports = {
+    routes: {
+        '/apps/starter': { host: `https://${localhost}:8002` },
+        '/insights/starter': { host: `https://${localhost}:8002` },
+    }
+};


### PR DESCRIPTION
https://github.com/RedHatInsights/insights-frontend-starter-app/blob/master/README.md#getting-started points users to ...

https://github.com/RedHatInsights/insights-frontend-storybook/blob/master/src/docs/welcome/quickStart/DOC.md

Which tells the user to start the proxy with a spandx config file that doesn't actually exist at the suggested location ...

```
SPANDX_CONFIG=path/to/insights-frontend-starter-app/config/spandx.config.js
```

This PR adds that file with a config that works for me locally with the example starter app.