### PR TITLE
RHCLOUD-46356: test: integrate playwright-test-auth package for e2e authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ cypress/videos
 # playwright
 playwright-report
 test-results
+playwright/.auth

--- a/.tekton/frontend-starter-app-pull-request.yaml
+++ b/.tekton/frontend-starter-app-pull-request.yaml
@@ -36,7 +36,7 @@ spec:
   - name: e2e-app-port
     value: "8000"
   - name: e2e-playwright-image
-    value: mcr.microsoft.com/playwright:v1.58.2-noble
+    value: mcr.microsoft.com/playwright:v1.59.1-noble
   - name: workspace-setup-script
     value: |
       #!/bin/bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -511,15 +511,23 @@ npx playwright show-report       # View HTML report
 - Retries: 2 on CI, 0 locally
 - Timeout: 120s per test, 10s per assertion
 - Parallel execution enabled
+- **Global setup**: Uses `@redhat-cloud-services/playwright-test-auth` for authentication
+- **Storage state**: Authentication state saved to `playwright/.auth/user.json` and reused across tests
 
 **Setup Requirements**:
 - **Environment variables**: `E2E_USER` and `E2E_PASSWORD` required for authentication
 - **Proxy config**: Tests expect proper proxy configuration (no "Lockdown" message)
 - **Stage environment**: Tests run against Red Hat staging environment
+- **Auth package**: `@redhat-cloud-services/playwright-test-auth` handles Red Hat SSO authentication
+
+**Authentication Strategy**:
+- **Global setup**: Authentication happens once before all tests via `globalSetup`
+- **Reusable state**: Login session stored in `playwright/.auth/user.json` and shared across tests
+- **No per-test login**: Tests automatically use the authenticated state without manual login
+- **Cookie handling**: Import `disableCookiePrompt` from the auth package to block TrustArc prompts
 
 **Patterns**:
-- **Authentication**: Use the `login()` helper function for SSO authentication
-- **Cookie prompt handling**: Use `disableCookiePrompt()` to prevent flaky tests
+- **Cookie prompt handling**: Use `disableCookiePrompt()` from `@redhat-cloud-services/playwright-test-auth`
 - **Page object pattern**: Extract common page interactions into reusable functions
 - **Waiting strategies**:
   - Use `waitForLoadState('load')` after navigation
@@ -531,12 +539,12 @@ npx playwright show-report       # View HTML report
 
 ```typescript
 import { test, expect } from '@playwright/test';
+import { disableCookiePrompt } from '@redhat-cloud-services/playwright-test-auth';
 
 test.describe('frontend starter app', () => {
   test.beforeEach(async ({ page }) => {
     await disableCookiePrompt(page);
     await page.goto('/');
-    // Handle login if needed
   });
 
   test('page loads with expected content', async ({ page }) => {
@@ -545,28 +553,13 @@ test.describe('frontend starter app', () => {
 });
 ```
 
-**Common Patterns**:
+**Manual Authentication** (if needed for special cases):
 
 ```typescript
-// Disable cookie prompt (prevents flaky tests)
-async function disableCookiePrompt(page: Page) {
-  await page.route('**/*', async (route, request) => {
-    if (request.url().includes('consent.trustarc.com')) {
-      await route.abort();
-    } else {
-      await route.continue();
-    }
-  });
-}
+import { login } from '@redhat-cloud-services/playwright-test-auth';
 
-// Login helper
-async function login(page: Page, user: string, password: string) {
-  await page.getByLabel('Red Hat login').first().fill(user);
-  await page.getByRole('button', { name: 'Next' }).click();
-  await page.getByLabel('Password').first().fill(password);
-  await page.getByRole('button', { name: 'Log in' }).click();
-  await expect(page.getByText('Invalid login')).not.toBeVisible();
-}
+// Manual login when global setup can't be used
+await login(page, process.env.E2E_USER!, process.env.E2E_PASSWORD!);
 ```
 
 ### Browser Compatibility

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "devDependencies": {
         "@cypress/code-coverage": "^3.14.7",
         "@cypress/react": "^9.0.1",
-        "@playwright/test": "^1.58.2",
+        "@playwright/test": "^1.59.1",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.31",
         "@redhat-cloud-services/frontend-components-config": "^6.7.54",
         "@redhat-cloud-services/playwright-test-auth": "^0.0.2",
@@ -4850,13 +4850,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -18498,13 +18498,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -18517,9 +18517,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@playwright/test": "^1.58.2",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.31",
         "@redhat-cloud-services/frontend-components-config": "^6.7.54",
+        "@redhat-cloud-services/playwright-test-auth": "^0.0.2",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.56",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^14.3.1",
@@ -4529,9 +4530,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4553,9 +4551,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4577,9 +4572,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4601,9 +4593,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4625,9 +4614,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4649,9 +4635,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5115,6 +5098,19 @@
       "dependencies": {
         "axios": "^1.12.2",
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@redhat-cloud-services/playwright-test-auth": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/playwright-test-auth/-/playwright-test-auth-0.0.2.tgz",
+      "integrity": "sha512-6B12razgM3Tyof1C63Dp6tKeWLOE+DdnrbezQ+kgRDJT76Wn8XdnkFAn5eZGT/eEgU27eGBkmnKTZIOoiUVBXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1.40.0",
+        "playwright": "^1.40.0"
       }
     },
     "node_modules/@redhat-cloud-services/rbac-client": {
@@ -5812,9 +5808,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5832,9 +5825,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5852,9 +5842,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5872,9 +5859,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7005,9 +6989,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7023,9 +7004,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7041,9 +7019,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7059,9 +7034,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7077,9 +7049,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7095,9 +7064,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7113,9 +7079,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7131,9 +7094,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -38,8 +38,10 @@
   "devDependencies": {
     "@cypress/code-coverage": "^3.14.7",
     "@cypress/react": "^9.0.1",
+    "@playwright/test": "^1.58.2",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.31",
     "@redhat-cloud-services/frontend-components-config": "^6.7.54",
+    "@redhat-cloud-services/playwright-test-auth": "^0.0.2",
     "@redhat-cloud-services/tsc-transform-imports": "^1.0.56",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^14.3.1",
@@ -57,8 +59,7 @@
     "ts-patch": "^3.3.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.1",
-    "webpack-bundle-analyzer": "4.10.2",
-    "@playwright/test": "^1.58.2"
+    "webpack-bundle-analyzer": "4.10.2"
   },
   "insights": {
     "appname": "frontend-starter-app"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@cypress/code-coverage": "^3.14.7",
     "@cypress/react": "^9.0.1",
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.59.1",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.31",
     "@redhat-cloud-services/frontend-components-config": "^6.7.54",
     "@redhat-cloud-services/playwright-test-auth": "^0.0.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
 
+  /* Global setup for authentication */
+  globalSetup: require.resolve('@redhat-cloud-services/playwright-test-auth/global-setup'),
+
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')` */
@@ -31,6 +34,9 @@ export default defineConfig({
 
     /* Ignore HTTPS errors */
     ignoreHTTPSErrors: true,
+
+    /* Reuse authentication state from global setup */
+    storageState: 'playwright/.auth/user.json',
   },
 
   /* Configure projects for major browsers */

--- a/playwright/frontend-starter-app.spec.ts
+++ b/playwright/frontend-starter-app.spec.ts
@@ -1,56 +1,10 @@
-import { Page, test, expect } from '@playwright/test';
-
-// Prevents inconsistent cookie prompting that is problematic for UI testing
-async function disableCookiePrompt(page: Page) {
-    await page.route('**/*', async (route, request) => {
-        if (request.url().includes('consent.trustarc.com') && request.resourceType() !== 'document') {
-            await route.abort();
-        } else {
-            await route.continue();
-        }
-    });
-}
-
-async function login(page: Page, user: string, password: string): Promise<void> {
-    // Fail in a friendly way if the proxy config is not set up correctly
-    await expect(page.locator("text=Lockdown"), 'proxy config incorrect').toHaveCount(0)
-
-    // Wait for and fill username field
-    await page.getByLabel('Red Hat login').first().fill(user);
-    await page.getByRole('button', { name: 'Next' }).click();
-
-    // Wait for and fill password field
-    await page.getByLabel('Password').first().fill(password);
-    await page.getByRole('button', { name: 'Log in' }).click();
-
-    // confirm login was valid
-    await expect(page.getByText('Invalid login')).not.toBeVisible();
-}
+import { test, expect } from '@playwright/test';
+import { disableCookiePrompt } from '@redhat-cloud-services/playwright-test-auth';
 
 test.describe('frontend starter app', async () => {
     test.beforeEach(async ({page}): Promise<void> => {
         await disableCookiePrompt(page);
         await page.goto('/', { waitUntil: 'load', timeout: 60000 });
-        const loggedIn = await page.getByText('Hi,').isVisible();
-        if (!loggedIn) {
-            const user = process.env.E2E_USER!;
-            const password = process.env.E2E_PASSWORD!;
-            // make sure the SSO prompt is loaded for login
-            await page.waitForLoadState("load");
-            await expect(page.locator("#username-verification")).toBeVisible();
-            await login(page, user, password);
-            await page.waitForLoadState("load");
-            await expect(page.getByText('Invalid login')).not.toBeVisible();
-            // long wait for the page to load; stage can be delicate
-            await page.waitForTimeout(5000);
-            await expect(page.getByRole('button', { name: 'Add widgets' }), 'dashboard not displayed').toBeVisible();
-
-            // conditionally accept cookie prompt
-            const acceptAllButton = page.getByRole('button', { name: 'Accept all'});
-            if (await acceptAllButton.isVisible()) {
-                await acceptAllButton.click();
-            }
-        }
     });
 
     test('starter app page loads and has the expected content', async({page}) => {


### PR DESCRIPTION
## Summary

Replaces custom login implementation with the new `@redhat-cloud-services/playwright-test-auth` package to centralize and standardize authentication handling across e2e tests.

**Key Changes:**
- Add `@redhat-cloud-services/playwright-test-auth@0.0.2` package
- Configure Playwright global setup for one-time authentication before all tests
- Use `storageState` to persist and reuse authenticated session across tests
- Remove custom `login()` and `disableCookiePrompt()` helper functions from test files
- Import `disableCookiePrompt` from the auth package instead
- Add `playwright/.auth` to `.gitignore` to prevent committing auth state files
- Update CLAUDE.md documentation with new authentication strategy

**Benefits:**
- **Faster test execution**: Authentication happens once at startup instead of per test
- **Simplified test code**: Reduced test setup from ~50 lines to 8 lines in `beforeEach`
- **Reusable utilities**: Centralized authentication logic shared across all tests
- **More reliable**: Consistent auth handling across the test suite

## Test Plan

- [x] Install dependencies: `npm install`
- [x] Set environment variables: `E2E_USER` and `E2E_PASSWORD`
- [x] Run Playwright tests: `npx playwright test`
- [ ] Verify tests authenticate successfully using global setup
- [ ] Verify `playwright/.auth/user.json` is created
- [ ] Verify tests run faster with session reuse
- [ ] Verify cookie prompts are still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Playwright to v1.59.1, added an authentication package, and updated CI test image.
* **Tests**
  * Refactored E2E setup to use a single, repository-wide authenticated session and simplified per-test initialization by removing local login/cookie handling.
* **Documentation**
  * Updated Playwright E2E authentication guidance and examples to match the new auth flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->