### PR TITLE
fix: prevent CSS chunk ERR_TOO_MANY_RETRIES errors in static mode

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -3,6 +3,7 @@ module.exports = {
   debug: true,
   useProxy: true,
   proxyVerbose: true,
+  useFileHash: false,
   /**
    * Change accordingly to your appname in package.json.
    * The `sassPrefix` attribute is only required if your `appname` includes the dash `-` characters.


### PR DESCRIPTION
## Description                                                                                                                                                            
  This PR improves intermittent CSS chunk loading failures with `ERR_TOO_MANY_RETRIES` errors when running `npm run static` alongside insights-chrome. The issue occurs because  `fec static` runs webpack --watch with production config (content-hashed filenames), causing the browser to request stale CSS URLs during rebuilds. Fix adds `useFileHash: false` to fec.config.js, forcing stable filenames (`css/[name].css`) so webpack overwrites files in-place during watch rebuilds, eliminating stale references.             
                                                                                                                                                                
  Affects local development workflow only. Production builds (`fec build`) ignore this setting and continue using content hashes for cache busting.                          
                                                                                                                                                                             
  [RHCLOUD-47224](https://issues.redhat.com/browse/RHCLOUD-47224)
                                                                                                                                                                             
  ---                                                                 
                                                                                                                                                                             
  ### Screenshots                                                     
  N/A - Dev tooling fix, no UI changes.
                                       
  ---                                                                                                                                                                        
     
  ### Checklist ☑️                                                                                                                                                            
  - [x] PR only fixes one issue or story                                                                                                                                     
  - [x] Change reviewed for extraneous code
  - [x] UI best practices adhered to                                                                                                                                         
  - [x] Commits squashed and meaningfully named (1 commit)            
  - [ ] All PR checks pass locally (build, lint, test, E2E)
                                                                                                                                                                             
  ##                                                                                                                                                                         
  - [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_                                                                      
  - [ ] _(Optional) QE: Has been mentioned_                                                                                                                                  
  - [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_                                                                                          
  - [ ] _(Optional) UX: Has been mentioned_

[RHCLOUD-47224]: https://redhat.atlassian.net/browse/RHCLOUD-47224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application configuration settings to adjust file processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->