### PR TITLE
chore: disable Dependabot — updates handled by Konflux

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,2 @@
+version: 2
+updates: []


### PR DESCRIPTION
Dependabot is disabled because dependency updates are handled through centralized Konflux flows. This avoids duplicate PRs and reduces review noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration file to use the latest schema version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->