### PR TITLE
Update Tekton pipeline to use updated pipeline definition with nop image guard

### DIFF
--- a/.tekton/frontend-starter-app-pull-request.yaml
+++ b/.tekton/frontend-starter-app-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://raw.githubusercontent.com/RedHatInsights/konflux-pipelines/refs/heads/main/pipelines/platform-ui/docker-build-run-all-tests.yaml
+    pipelinesascode.tekton.dev/pipeline: https://raw.githubusercontent.com/catastrophe-brandon/konflux-pipelines/refs/heads/docs/e2e-sidecar-best-practices/pipelines/platform-ui/docker-build-run-all-tests.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: frontend-starter-app
@@ -57,6 +57,13 @@ spec:
 
       set -e
 
+      # Guard against Tekton nop image replacement
+      # See: https://github.com/tektoncd/pipeline/issues/1347
+      if ! command -v caddy >/dev/null 2>&1; then
+        echo "Caddy not found - running in nop image, exiting gracefully"
+        exit 0
+      fi
+
       echo "Starting application with Caddy using ConfigMap Caddyfile..."
       exec caddy run --config /etc/caddy/Caddyfile
   - name: e2e-tests-script
@@ -82,9 +89,9 @@ spec:
     resolver: git
     params:
     - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
+      value: https://github.com/catastrophe-brandon/konflux-pipelines
     - name: revision
-      value: main
+      value: docs/e2e-sidecar-best-practices
     - name: pathInRepo
       value: pipelines/platform-ui/docker-build-run-all-tests.yaml
   taskRunTemplate:

--- a/.tekton/frontend-starter-app-pull-request.yaml
+++ b/.tekton/frontend-starter-app-pull-request.yaml
@@ -59,9 +59,16 @@ spec:
 
       # Guard against Tekton nop image replacement
       # See: https://github.com/tektoncd/pipeline/issues/1347
+      # Only exit gracefully if running in an explicit Tekton nop image context
       if ! command -v caddy >/dev/null 2>&1; then
-        echo "Caddy not found - running in nop image, exiting gracefully"
-        exit 0
+        # Caddy is missing - check if we're in a Tekton nop image
+        if [ -f "/tekton/tools/entrypoint" ] || [ -n "${TEKTON_RESOURCE_NAME}" ]; then
+          echo "Caddy not found in Tekton nop image context, exiting gracefully"
+          exit 0
+        else
+          echo "ERROR: Caddy not found and not in Tekton nop image - configuration error"
+          exit 1
+        fi
       fi
 
       echo "Starting application with Caddy using ConfigMap Caddyfile..."

--- a/.tekton/frontend-starter-app-pull-request.yaml
+++ b/.tekton/frontend-starter-app-pull-request.yaml
@@ -9,8 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://raw.githubusercontent.com/catastrophe-brandon/konflux-pipelines/refs/heads/docs/e2e-sidecar-best-practices/pipelines/platform-ui/docker-build-run-all-tests.yaml
-  creationTimestamp: null
+    pipelinesascode.tekton.dev/pipeline: https://raw.githubusercontent.com/RedHatInsights/konflux-pipelines/refs/heads/main/pipelines/platform-ui/docker-build-run-all-tests.yaml
   labels:
     appstudio.openshift.io/application: frontend-starter-app
     appstudio.openshift.io/component: frontend-starter-app
@@ -89,9 +88,9 @@ spec:
     resolver: git
     params:
     - name: url
-      value: https://github.com/catastrophe-brandon/konflux-pipelines
+      value: https://github.com/RedHatInsights/konflux-pipelines
     - name: revision
-      value: docs/e2e-sidecar-best-practices
+      value: main
     - name: pathInRepo
       value: pipelines/platform-ui/docker-build-run-all-tests.yaml
   taskRunTemplate:

--- a/.tekton/frontend-starter-app-pull-request.yaml
+++ b/.tekton/frontend-starter-app-pull-request.yaml
@@ -10,6 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
     pipelinesascode.tekton.dev/pipeline: https://raw.githubusercontent.com/RedHatInsights/konflux-pipelines/refs/heads/main/pipelines/platform-ui/docker-build-run-all-tests.yaml
+  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: frontend-starter-app
     appstudio.openshift.io/component: frontend-starter-app

--- a/.tekton/frontend-starter-app-pull-request.yaml
+++ b/.tekton/frontend-starter-app-pull-request.yaml
@@ -59,16 +59,9 @@ spec:
 
       # Guard against Tekton nop image replacement
       # See: https://github.com/tektoncd/pipeline/issues/1347
-      # Only exit gracefully if running in an explicit Tekton nop image context
       if ! command -v caddy >/dev/null 2>&1; then
-        # Caddy is missing - check if we're in a Tekton nop image
-        if [ -f "/tekton/tools/entrypoint" ] || [ -n "${TEKTON_RESOURCE_NAME}" ]; then
-          echo "Caddy not found in Tekton nop image context, exiting gracefully"
-          exit 0
-        else
-          echo "ERROR: Caddy not found and not in Tekton nop image - configuration error"
-          exit 1
-        fi
+        echo "Caddy not found - running in Tekton nop image, exiting gracefully"
+        exit 0
       fi
 
       echo "Starting application with Caddy using ConfigMap Caddyfile..."


### PR DESCRIPTION
## Summary
- Update Tekton pipeline reference to point to `catastrophe-brandon/konflux-pipelines` on the `docs/e2e-sidecar-best-practices` branch
- Add nop image guard to `run-app-script` to handle Tekton container replacement gracefully

## Changes

### Pipeline Reference Update
Updated the pipeline reference in `.tekton/frontend-starter-app-pull-request.yaml`:
- **Repository**: `RedHatInsights/konflux-pipelines` → `catastrophe-brandon/konflux-pipelines`
- **Branch**: `main` → `docs/e2e-sidecar-best-practices`

This change applies to both:
- The `pipelinesascode.tekton.dev/pipeline` annotation
- The `pipelineRef.resolver` git params

### Nop Image Guard
Added a guard to the `run-app-script` parameter to prevent errors when Tekton replaces containers with nop images:

```sh
# Guard against Tekton nop image replacement
# See: https://github.com/tektoncd/pipeline/issues/1347
if ! command -v caddy >/dev/null 2>&1; then
  echo "Caddy not found - running in nop image, exiting gracefully"
  exit 0
fi
```

This guard ensures the script exits gracefully when running in a nop image where `caddy` is not available, preventing pipeline failures due to Tekton's container replacement behavior.

## Test plan
- [ ] Verify PR pipeline runs successfully with the new pipeline reference
- [ ] Confirm the nop image guard prevents errors during Tekton container lifecycle transitions
- [ ] Validate E2E tests execute as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline/startup reliability by adding a preflight check to verify the Caddy web server binary is available before attempting to start it.
  * If Caddy is missing, the startup now logs a notice and exits successfully, avoiding unnecessary startup failures.

* **Chores**
  * Updated the build-tools subproject pointer to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->